### PR TITLE
Bring frontend resource into spec

### DIFF
--- a/config/frontend.yml
+++ b/config/frontend.yml
@@ -8,6 +8,12 @@ objects:
     metadata:
       name: platform-docs
     spec:
+      API:
+        versions:
+          - v1
+      frontend:
+        paths:
+          - /apps/platform-docs
       envName: ${ENV_NAME}
       title: platform-docs
       deploymentRepo: https://github.com/RedHatInsights/better-platform-docs


### PR DESCRIPTION
We're seeing pipeline failures for frontend-base due in part to the frontend resource in this repo not conforming to spec:

```
The Frontend "platform-docs" is invalid: 
* spec.API: Required value
* spec.frontend: Required value
 (error details: https://github.com/RedHatInsights/better-platform-docs/blob/main/config/frontend.yml)
```
This patch should stop the failures.
