### PR TITLE
Scan for images after asciidoc run was complete.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/cloudservices/releaser:24ff556
+FROM quay.io/cloudservices/releaser:6969d44
 COPY . .
 USER root
 COPY ./Caddyfile /opt/app-root/src/Caddyfile

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM quay.io/cloudservices/releaser:24ff556
+FROM quay.io/cloudservices/releaser:6969d44
 WORKDIR /docs
 COPY . /docs/
 USER root

--- a/downloader/transformers.mjs
+++ b/downloader/transformers.mjs
@@ -78,10 +78,6 @@ const transformerMapper = {
   }) => {
     const sourcePath = getSource(repository, branch, path);
     const adocFiles = glob.sync(`${sourcePath}/**/pages/**/*.adoc`);
-    const images = [
-      glob.sync(`${sourcePath}/**/pages/**/*.png`),
-      glob.sync(`${sourcePath}/**/images/*.png`),
-    ].flat();
     process.env.IMAGE_PREFIX = `./public/${title
       .replaceAll(" ", "-")
       .toLowerCase()}/${path.split("/").pop()}`;
@@ -94,7 +90,10 @@ const transformerMapper = {
     });
     // wait for transformation to finish
     await Promise.all(promises);
-
+    const images = [
+      glob.sync(`${sourcePath}/**/pages/**/*.png`),
+      glob.sync(`${sourcePath}/**/images/*.png`),
+    ].flat();
     images.forEach((image) => {
       renameSync(image, image.replace("/pages/", "/").replace("/images/", "/"));
     });


### PR DESCRIPTION
### Changes
- move CCS pages image relocation after acidic files are parsed (we were getting files path before they were generated)
- bump the release image to use correct version of Java to properly generate asciidoc diagrams