### PR TITLE
Tweak github styling  link in masthead

### DIFF
--- a/components/header/header.tsx
+++ b/components/header/header.tsx
@@ -64,8 +64,8 @@ const Header = () => {
               </ToolbarItem>
             </ToolbarGroup>
             <ToolbarGroup
-              className="pf-m-align-right pf-m-spacer-md"
-              visibility={{ default: "hidden", xl: "visible" }}
+              className="pf-m-align-right pf-m-spacer-md pf-u-mr-xs"
+              visibility={{ default: "hidden", lg: "visible" }}
             >
               <ToolbarItem className={clsx("pf-u-px-xl", classes.toolbarItem)}>
                 <TextContent className={classes.link}>


### PR DESCRIPTION
<img width="379" alt="Screenshot 2023-07-20 at 2 54 33 PM" src="https://github.com/RedHatInsights/better-platform-docs/assets/1287144/0b4d1378-875d-4058-88a2-58dd981ac334">
