### PR TITLE
Update docs to recommend PF component groups migration

### DIFF
--- a/components/layouts/BaseLayout/index.tsx
+++ b/components/layouts/BaseLayout/index.tsx
@@ -63,7 +63,7 @@ const BaseLayout: React.FC<PropsWithChildren> = ({ children }) => {
         stickyOnBreakpoint: { default: "top" },
       }}
       additionalGroupedContent={
-        navItems.length > 0 ? (
+        navItems.length > 0 && !"Note: Hidden until RHCLOUD-28585 is done" ? (
           <PageSection variant={PageSectionVariants.light} isWidthLimited>
             <TextContent>
               <Text component="h1">Section name</Text>

--- a/pages/guides/frontend-migrations/frontend-components-3-to-4.md
+++ b/pages/guides/frontend-migrations/frontend-components-3-to-4.md
@@ -1,6 +1,14 @@
 # Frontend components @3 -> @4 migration
 
-There are a small number of breaking changes in this release. Most of them impose stricter props requirements and  the removal of a some default prop values.
+### Before you start reading... 
+
+Consider migration to the new shared components extension [patternfly/react-component-groups](https://github.com/patternfly/react-component-groups) instead of upgrading your frontend-components version. Component groups bring PatternFly 5, improved and cleaner components, better docs and much more! 
+
+[See the Component groups migration guide](./frontend-components-to-PF-component-groups.md)
+
+---
+
+There is a small number of breaking changes in this release. Most of them impose stricter props requirements and  the removal of a some default prop values.
 
 ## Conditional filter
 

--- a/pages/guides/frontend-migrations/pf-4-to-pf5.mdx
+++ b/pages/guides/frontend-migrations/pf-4-to-pf5.mdx
@@ -119,11 +119,17 @@ The `@data-driven-forms` packages require a version bump. There are no breaking 
 - @redhat-cloud-services/types@1.0.0
 - @redhat-cloud-services/frontend-components-utilities@4.0.0
 
+  **Note:** When updating version of @redhat-cloud-services/frontend-components, consider [migration](./frontend-components-to-PF-component-groups.md) to the new shared components extension [patternfly/react-component-groups](https://github.com/patternfly/react-component-groups) instead. The Component groups extension brings not only PatternFly 5, but also improved and cleaner components, better docs and more!
+
+--- 
+
 **Beta releases**
 - @redhat-cloud-services/frontend-components-advisor-components@2.0.0-beta.0
 - @redhat-cloud-services/frontend-components-charts@4.0.0-beta.0
 - @redhat-cloud-services/frontend-components-remediations@4.0.0-beta.0
 - @redhat-cloud-services/rule-components@4.0.0-beta.0
+
+---
 
 ## Installing dependencies
 


### PR DESCRIPTION
[RHCLOUD-29539](https://issues.redhat.com/browse/RHCLOUD-29539)