### PR TITLE
Display correct label for code vs design on landing page

### DIFF
--- a/components/Navigation/SectionNavigation.tsx
+++ b/components/Navigation/SectionNavigation.tsx
@@ -48,59 +48,73 @@ export type NavRecord = Partial<Record<SectionType, SectionItem[]>>;
 
 const SectionNavigation = ({ navigations }: { navigations: SectionType[] }) => {
   const classes = useStyles();
+
+  const getLabelProps = (
+    category: string
+  ): { labelColor: string; labelIcon: React.ReactNode } => {
+    switch (category) {
+      case "code":
+        return {
+          labelColor: "orange",
+          labelIcon: <CommandLineIcon width="16" height="16" />,
+        };
+      case "design":
+        return {
+          labelColor: "purple",
+          labelIcon: <PenToolIcon width="16" height="16" />,
+        };
+      default:
+        return {
+          labelColor: "purple",
+          labelIcon: <PenToolIcon width="16" height="16" />,
+        };
+    }
+  };
+
   return (
     <Gallery
       className={classnames(classes.gallery, "pf-u-display-block")}
       hasGutter
     >
-      {navigations.flatMap((parentKey) => (
-        <GalleryItem key={parentKey}>
-          <Card
-            key={parentKey}
-            className={classnames(
-              classes.card,
-              "pf-u-display-block pf-u-mb-md pf-u-background-color-100"
-            )}
-            isSelectable
-          >
-            <CardTitle className="pf-u-pb-md">
-              {(sections[parentKey as SectionType] as { title: string }).title}
-              {(sections[parentKey as SectionType] as { category: string })
-                .category === "code" ? (
-                <Label
-                  color="orange"
-                  className={classnames(classes.label, "pf-u-float-right")}
-                >
-                  <CommandLineIcon width="16" height="16" />
-                </Label>
-              ) : (
-                <Label
-                  color="purple"
-                  className={classnames(classes.label, "pf-u-float-right")}
-                >
-                  <PenToolIcon width="16" height="16" />
-                </Label>
+      {navigations.flatMap((parentKey) => {
+        const { title, items, category } = sections[parentKey as SectionType];
+        const { labelColor, labelIcon } = getLabelProps(category || "default");
+
+        return (
+          <GalleryItem key={parentKey}>
+            <Card
+              key={parentKey}
+              className={classnames(
+                classes.card,
+                "pf-u-display-block pf-u-mb-md pf-u-background-color-100"
               )}
-            </CardTitle>
-            <CardBody>
-              <List isPlain>
-                {(
-                  sections[parentKey as SectionType] as {
-                    items: SectionItem[];
-                  }
-                ).items.map(({ title, href, indexPage }, key) => (
-                  <ListItem
-                    key={`${parentKey}-${key}`}
-                    className="pf-u-font-size-sm pf-u-pb-sm"
-                  >
-                    <Link href={indexPage ?? href}>{title}</Link>
-                  </ListItem>
-                ))}
-              </List>
-            </CardBody>
-          </Card>
-        </GalleryItem>
-      ))}
+              isSelectable
+            >
+              <CardTitle className="pf-u-pb-md">
+                {title}
+                <Label
+                  color={labelColor as "orange" | "purple"}
+                  className={classnames(classes.label, "pf-u-float-right")}
+                >
+                  {labelIcon}
+                </Label>
+              </CardTitle>
+              <CardBody>
+                <List isPlain>
+                  {items.map(({ title, href, indexPage }, key) => (
+                    <ListItem
+                      key={`${parentKey}-${key}`}
+                      className="pf-u-font-size-sm pf-u-pb-sm"
+                    >
+                      <Link href={indexPage || href}>{title}</Link>
+                    </ListItem>
+                  ))}
+                </List>
+              </CardBody>
+            </Card>
+          </GalleryItem>
+        );
+      })}
     </Gallery>
   );
 };

--- a/components/Navigation/SectionNavigation.tsx
+++ b/components/Navigation/SectionNavigation.tsx
@@ -77,8 +77,10 @@ const SectionNavigation = ({ navigations }: { navigations: SectionType[] }) => {
       hasGutter
     >
       {navigations.flatMap((parentKey) => {
-        const { title, items, category } = sections[parentKey as SectionType];
-        const { labelColor, labelIcon } = getLabelProps(category || "default");
+        const section = sections[parentKey as SectionType];
+        const category = "category" in section ? section.category : "default";
+        const { title, items } = section;
+        const { labelColor, labelIcon } = getLabelProps(category);
 
         return (
           <GalleryItem key={parentKey}>
@@ -101,12 +103,20 @@ const SectionNavigation = ({ navigations }: { navigations: SectionType[] }) => {
               </CardTitle>
               <CardBody>
                 <List isPlain>
-                  {items.map(({ title, href, indexPage }, key) => (
+                  {items.map((item, key) => (
                     <ListItem
                       key={`${parentKey}-${key}`}
                       className="pf-u-font-size-sm pf-u-pb-sm"
                     >
-                      <Link href={indexPage || href}>{title}</Link>
+                      <Link
+                        href={
+                          "indexPage" in item && item.indexPage
+                            ? item.indexPage
+                            : item.href
+                        }
+                      >
+                        {item.title}
+                      </Link>
                     </ListItem>
                   ))}
                 </List>

--- a/components/Navigation/SectionNavigation.tsx
+++ b/components/Navigation/SectionNavigation.tsx
@@ -38,6 +38,7 @@ const useStyles = createUseStyles({
 export type SectionType = keyof typeof sections;
 export type SectionItem = {
   title: string;
+  category?: string;
   href: string;
   indexPage?: string;
   groupTitle?: string;
@@ -64,13 +65,22 @@ const SectionNavigation = ({ navigations }: { navigations: SectionType[] }) => {
           >
             <CardTitle className="pf-u-pb-md">
               {(sections[parentKey as SectionType] as { title: string }).title}
-              <Label
-                color="orange"
-                className={classnames(classes.label, "pf-u-float-right")}
-              >
-                <CommandLineIcon width="16" height="16" />
-              </Label>
-              {/*<Label color="purple" className={classnames(classes.label, "pf-u-float-right")}><PenToolIcon/></Label>*/}
+              {(sections[parentKey as SectionType] as { category: string })
+                .category === "code" ? (
+                <Label
+                  color="orange"
+                  className={classnames(classes.label, "pf-u-float-right")}
+                >
+                  <CommandLineIcon width="16" height="16" />
+                </Label>
+              ) : (
+                <Label
+                  color="purple"
+                  className={classnames(classes.label, "pf-u-float-right")}
+                >
+                  <PenToolIcon width="16" height="16" />
+                </Label>
+              )}
             </CardTitle>
             <CardBody>
               <List isPlain>

--- a/components/Navigation/SectionNavigation.tsx
+++ b/components/Navigation/SectionNavigation.tsx
@@ -38,11 +38,15 @@ const useStyles = createUseStyles({
 export type SectionType = keyof typeof sections;
 export type SectionItem = {
   title: string;
-  category?: string;
   href: string;
   indexPage?: string;
   groupTitle?: string;
   groups?: { title: string }[];
+};
+export type NavSection = {
+  title: string;
+  items: SectionItem[];
+  category?: string;
 };
 export type NavRecord = Partial<Record<SectionType, SectionItem[]>>;
 
@@ -77,10 +81,9 @@ const SectionNavigation = ({ navigations }: { navigations: SectionType[] }) => {
       hasGutter
     >
       {navigations.flatMap((parentKey) => {
-        const section = sections[parentKey as SectionType];
-        const category = "category" in section ? section.category : "default";
-        const { title, items } = section;
-        const { labelColor, labelIcon } = getLabelProps(category);
+        const section = sections[parentKey as SectionType] as NavSection;
+        const { title, items, category } = section;
+        const { labelColor, labelIcon } = getLabelProps(category || "default");
 
         return (
           <GalleryItem key={parentKey}>
@@ -103,20 +106,12 @@ const SectionNavigation = ({ navigations }: { navigations: SectionType[] }) => {
               </CardTitle>
               <CardBody>
                 <List isPlain>
-                  {items.map((item, key) => (
+                  {items.map(({ title, indexPage, href }, key) => (
                     <ListItem
                       key={`${parentKey}-${key}`}
                       className="pf-u-font-size-sm pf-u-pb-sm"
                     >
-                      <Link
-                        href={
-                          "indexPage" in item && item.indexPage
-                            ? item.indexPage
-                            : item.href
-                        }
-                      >
-                        {item.title}
-                      </Link>
+                      <Link href={indexPage || href}>{title}</Link>
                     </ListItem>
                   ))}
                 </List>

--- a/components/Navigation/SectionNavigation.tsx
+++ b/components/Navigation/SectionNavigation.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import sections from "./sections/sections.json";
+import sectionMeta from "./section-meta.json";
 import {
   Bullseye,
   Card,
@@ -82,8 +83,9 @@ const SectionNavigation = ({ navigations }: { navigations: SectionType[] }) => {
     >
       {navigations.flatMap((parentKey) => {
         const section = sections[parentKey as SectionType] as NavSection;
-        const { title, items, category } = section;
-        const { labelColor, labelIcon } = getLabelProps(category || "default");
+        const { title, items } = section;
+        const category = sectionMeta[parentKey]?.category || "default";
+        const { labelColor, labelIcon } = getLabelProps(category);
 
         return (
           <GalleryItem key={String(parentKey)}>

--- a/components/Navigation/SectionNavigation.tsx
+++ b/components/Navigation/SectionNavigation.tsx
@@ -86,9 +86,9 @@ const SectionNavigation = ({ navigations }: { navigations: SectionType[] }) => {
         const { labelColor, labelIcon } = getLabelProps(category || "default");
 
         return (
-          <GalleryItem key={parentKey}>
+          <GalleryItem key={String(parentKey)}>
             <Card
-              key={parentKey}
+              key={String(parentKey)}
               className={classnames(
                 classes.card,
                 "pf-u-display-block pf-u-mb-md pf-u-background-color-100"
@@ -108,7 +108,7 @@ const SectionNavigation = ({ navigations }: { navigations: SectionType[] }) => {
                 <List isPlain>
                   {items.map(({ title, indexPage, href }, key) => (
                     <ListItem
-                      key={`${parentKey}-${key}`}
+                      key={`${String(parentKey)}-${key}`}
                       className="pf-u-font-size-sm pf-u-pb-sm"
                     >
                       <Link href={indexPage || href}>{title}</Link>

--- a/components/Navigation/section-meta.json
+++ b/components/Navigation/section-meta.json
@@ -1,0 +1,29 @@
+{
+    "chroming-service": {
+        "category": "code"
+    },
+    "consoledot-pages": {
+        "category": "design"
+    },
+    "deployment": {
+        "category": "design"
+    },
+    "frontend-components": {
+        "category": "design"
+    },
+    "frontend-tips-and-tricks": {
+        "category": "code"
+    },
+    "guides": {
+        "category": "design"
+    },
+    "hac-initiative": {
+        "category": "code"
+    },
+    "landing-page": {
+        "category": "design"
+    },
+    "platform-experience": {
+        "category": "design"
+    }
+}


### PR DESCRIPTION
# [RHCLOUD-26902](https://issues.redhat.com/browse/RHCLOUD-26902)
Added `section-meta.json` and used it to display appropriate section labels

## Before
![image](https://github.com/RedHatInsights/better-platform-docs/assets/39098327/a07dde2d-1c45-4f17-a02d-f4685f0ba04a)

## After
![image](https://github.com/RedHatInsights/better-platform-docs/assets/39098327/d2f762a5-c513-4785-95c6-b39988dbcc3a)
