### PR TITLE
Add Information to PF5 Migration Guide

### DIFF
--- a/pages/guides/frontend-migrations/pf-4-to-pf5.mdx
+++ b/pages/guides/frontend-migrations/pf-4-to-pf5.mdx
@@ -30,6 +30,8 @@ Your package manager might throw a few errors while upgrading your dependencies.
 
 Most of the time, we are talking about a formal dependency bump with no actual code changes.
 
+After successfully upgrading to React 18, please have a look at [this react.dev blog](https://react.dev/blog/2022/03/08/react-18-upgrade-guide#updates-to-client-rendering-apis) specifying some important changes regarding updates to client rendering APIs. Until you switch to the new API, your app will behave as if it’s running React 17.
+
 ### Sample installation error
 
 Here is an example error of `npm ci` with invalid peer dependencies:


### PR DESCRIPTION
This PR adds important information regarding the React 18 upgrade, which should be done during the migration to PF5