### PR TITLE
[Better-Platform-Docs] Adding Jenkins Security Scan Script

### DIFF
--- a/security-scan.sh
+++ b/security-scan.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+###########################
+# This script sources the security-scan.sh script from 
+# https://github.com/RedHatInsights/platform-security-gh-workflow
+# This script, in combination with Jenkins, scans a repo's Dockerfile
+# to provide a Software Bill of Materials (SBOM) and scan security vulnerabilities.
+###########################
+
+set -exv
+
+IMAGE_NAME="better-platform-docs"
+DOCKERFILE_LOCATION="."
+
+# (Severity Options: negligible, low, medium, high, critical)
+FAIL_ON_SEVERITY="high"
+
+# Build on Podman or Docker
+PODMAN_OR_DOCKER="docker"
+
+curl -sSL https://raw.githubusercontent.com/RedHatInsights/platform-security-gh-workflow/master/jenkins/security-scan.sh | \
+    sh -s "${IMAGE_NAME}" "${DOCKERFILE_LOCATION}" "${FAIL_ON_SEVERITY}" "${PODMAN_OR_DOCKER}"


### PR DESCRIPTION
## Overview

Adding the Security Scanning Workflow. This script will provide the same level of support as the standard PlatSec GitHub Workflow.

A copy of the [security-scan-source-template.sh](https://github.com/RedHatInsights/platform-security-gh-workflow/blob/master/jenkins/security-scan-source-template.sh) has been added to this repo, and the (GitHub) `platsec-gh-vulnerability-scan` Jenkins Job has be added to the better-platform-docs `build.yml` in App-Interface.

Similar to the standard GitHub Workflow, we can accommodate feature requests and provide updates on the fly and with full transparency. The `security-scan-source-template.sh` script, which sources the main [security-scan.sh](https://github.com/RedHatInsights/platform-security-gh-workflow/blob/master/jenkins/security-scan.sh) script, allows us to support multiple teams without having to open up multiple PRs across multiple repos.

In the checks associated with this PR you will find the `ci.int.devshift.net Grype Vulnerability Scan`. Inside of Jenkins you will see the output of the scan. The scan consists of the following items:

- `Software Bill of Materials (SBOM)` | Text (Human Readable) & JSON (Verbose)
- `Vulnerability Scan (Full Listing)` |  | Text (Human Readable) & JSON (Verbose)
- `Vulnerability Scan (Fixable)` |  | Text (Human Readable) & JSON (Verbose)

The Jenkins job will fail if there is a fixable vulnerability is found with a severity of `High` or greater. 

For more information please check out the [PlatSec GH Workflow repo](https://github.com/RedHatInsights/platform-security-gh-workflow).